### PR TITLE
Fixed 3 missing dependencies in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 
 namespaced_parser : namespaced_parser.o snazzle_lex.o snazzle_parse.o
 
+snazzle_lex.o: snazzle_common.h snazzle_parse.h
+
 snazzle_parse.o : snazzle_lex.h snazzle_common.h snazzle_parse.h
 
 namespaced_parser.o: snazzle_parse.h snazzle_lex.h snazzle_common.h

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 
 namespaced_parser : namespaced_parser.o snazzle_lex.o snazzle_parse.o
 
-snazzle_parse.o : snazzle_lex.h
+snazzle_parse.o : snazzle_lex.h snazzle_common.h snazzle_parse.h
 
-namespaced_parser.o: snazzle_parse.h snazzle_lex.h
+namespaced_parser.o: snazzle_parse.h snazzle_lex.h snazzle_common.h
 
 %.c %.h : %.l
 	flex --outfile=$(basename $<).c --header-file=$(basename $<).h $<


### PR DESCRIPTION
Hi, I've fixed 3 dependencies missing reported.
Those issues can cause incorrect results when namespaced_parser is incrementally built.
For example, any changes in "snazzle_common.h" and "snazzle_parse.h" will not cause "snazzle_parse.o" to be rebuilt, which is incorrect.
Looking forward to your confirmation.

Thanks
Vemake